### PR TITLE
i18nを導入しました

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -62,3 +62,5 @@ group :test do
 end
 
 gem "devise"
+gem 'rails-i18n'
+gem 'devise-i18n'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,8 @@ GEM
       railties (>= 4.1.0)
       responders
       warden (~> 1.2.3)
+    devise-i18n (1.12.1)
+      devise (>= 4.9.0)
     diff-lcs (1.5.1)
     drb (2.2.1)
     erubi (1.13.1)
@@ -221,6 +223,9 @@ GEM
     rails-html-sanitizer (1.6.2)
       loofah (~> 2.21)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
+    rails-i18n (7.0.10)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.2.2.1)
       actionpack (= 7.2.2.1)
       activesupport (= 7.2.2.1)
@@ -356,11 +361,13 @@ DEPENDENCIES
   cssbundling-rails
   debug
   devise
+  devise-i18n
   jbuilder
   jsbundling-rails
   pg (~> 1.1)
   puma (>= 5.0)
   rails (~> 7.2.2, >= 7.2.2.1)
+  rails-i18n
   rubocop
   rubocop-performance
   rubocop-rails

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -2,24 +2,19 @@ class PostsController < ApplicationController
   before_action :set_post, only: %i[ show destroy ]
   before_action :authenticate_user!, only: %i[ create destroy show index ]
 
-  # GET /posts or /posts.json
   def index
     @posts = Post.all.order(created_at: :desc)
   end
 
-  # GET /posts/1 or /posts/1.json
   def show; end
 
-  # POST /posts or /posts.json
   def create
     @post = Post.new(post_params)
 
-    respond_to do |format|
-      if @post.save
-        redirect_to posts_path, notice: "宣言しました！"
-      else
-        render :index, status: :unprocessable_entity
-      end
+    if @post.save
+      redirect_to posts_path, notice: "宣言しました！"
+    else
+      render :index, status: :unprocessable_entity
     end
   end
 
@@ -31,12 +26,10 @@ class PostsController < ApplicationController
 
   private
 
-  # Use callbacks to share common setup or constraints between actions.
   def set_post
     @post = Post.find(params[:id])
   end
 
-  # Only allow a list of trusted parameters through.
   def post_params
     params.require(:post).permit(:name, :option, :user_id)
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -37,7 +37,7 @@
           <div class="hidden md:flex space-x-8">
             <%= link_to "このアプリって？", about_path,class: "text-gray-600 hover:text-gray-800 font-medium" %>
             <% if user_signed_in? %>
-              <%= link_to "ここから", posts_path, class: "text-gray-600 hover:text-gray-800 font-medium" %> 
+              <%= link_to "ここから", posts_path, data: {turbo: false}, class: "text-gray-600 hover:text-gray-800 font-medium" %> 
               <%= link_to "ログアウト" , destroy_user_session_path, data: { turbo_method: :delete }, class: "text-red-600 hover:text-red-800 font-medium" %>
             <% else %>
               <%= link_to "ログイン", new_user_session_path, class: "text-blue-600 hover:text-blue-800 font-medium" %>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -28,10 +28,17 @@
 </button>
 
   <!-- ドロップダウンボタン（上方向に表示） -->
-  <div id="dropdown-buttons" class="hidden absolute bottom-full right-0 flex flex-col items-end gap-2 mb-2 w-40 bg-white rounded-lg shadow-lg">
-    <!-- Option 1 -->
-    <%= link_to "張り切って", posts_path(post:{option: 0, name: current_user.name, user_id: current_user.id}), data: { "turbo-method": :post }, class: "bg-green-600 text-white rounded-lg py-2 px-4 shadow-md hover:bg-green-700 focus:outline-none dropdown-item w-full text-center" %>
-    <!-- Option 2 -->
-    <%= link_to "この辺で終わる", posts_path(post:{option: 1, name: current_user.name, user_id: current_user.id}), data: { "turbo-method": :post }, class: "bg-green-600 text-white rounded-lg py-2 px-4 shadow-md hover:bg-green-700 focus:outline-none dropdown-item w-full text-center" %>
-  </div>
+<div id="dropdown-buttons" class="hidden absolute bottom-full right-0 flex flex-col items-end gap-2 mb-2 w-40">
+  <!-- Option 1 -->
+  <%= button_to "張り切って", posts_path(post:{option: 0, name: current_user.name, user_id: current_user.id}), 
+    method: :post, 
+    data: { turbo: false }, 
+    class: "bg-green-600 text-white rounded-lg py-2 px-4 shadow-md hover:bg-green-700 focus:outline-none dropdown-item w-full text-center appearance-none" %>
+  
+  <!-- Option 2 -->
+  <%= button_to "この辺で終わる", posts_path(post:{option: 1, name: current_user.name, user_id: current_user.id}), 
+    method: :post, 
+    data: { turbo: false }, 
+    class: "bg-green-600 text-white rounded-lg py-2 px-4 shadow-md hover:bg-green-700 focus:outline-none dropdown-item w-full text-center appearance-none" %>
+</div>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,7 +10,7 @@ module Myapp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.2
-
+    config.i18n.default_locale = :ja
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -1,0 +1,144 @@
+ja:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: パスワード確認送信時刻
+        confirmation_token: パスワード確認用トークン
+        confirmed_at: パスワード確認時刻
+        created_at: 作成日
+        current_password: 現在のパスワード
+        current_sign_in_at: 現在のログイン時刻
+        current_sign_in_ip: 現在のログインIPアドレス
+        email: Eメール
+        encrypted_password: 暗号化パスワード
+        failed_attempts: 失敗したログイン試行回数
+        last_sign_in_at: 最終ログイン時刻
+        last_sign_in_ip: 最終ログインIPアドレス
+        locked_at: ロック時刻
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        remember_created_at: ログイン記憶時刻
+        remember_me: ログインを記憶する
+        reset_password_sent_at: パスワードリセット送信時刻
+        reset_password_token: パスワードリセット用トークン
+        sign_in_count: ログイン回数
+        unconfirmed_email: 未確認Eメール
+        unlock_token: ロック解除用トークン
+        updated_at: 更新日
+    models:
+      user: ユーザー
+  devise:
+    confirmations:
+      confirmed: メールアドレスが確認できました。
+      new:
+        resend_confirmation_instructions: アカウント確認メール再送
+      send_instructions: アカウントの有効化について数分以内にメールでご連絡します。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、本人確認用のメールが数分以内に送信されます。
+    failure:
+      already_authenticated: すでにログインしています。
+      inactive: アカウントが有効化されていません。メールに記載された手順にしたがって、アカウントを有効化してください。
+      invalid: "%{authentication_keys}またはパスワードが違います。"
+      last_attempt: もう一回誤るとアカウントがロックされます。
+      locked: アカウントはロックされています。
+      not_found_in_database: "%{authentication_keys}またはパスワードが違います。"
+      timeout: セッションがタイムアウトしました。もう一度ログインしてください。
+      unauthenticated: ログインもしくはアカウント登録してください。
+      unconfirmed: メールアドレスの本人確認が必要です。
+    mailer:
+      confirmation_instructions:
+        action: メールアドレスの確認
+        greeting: "%{recipient}様"
+        instruction: 以下のリンクをクリックし、メールアドレスの確認手続を完了させてください。
+        subject: メールアドレス確認メール
+      email_changed:
+        greeting: こんにちは、%{recipient}様。
+        message: メールアドレスの（%{email}）変更が完了したため、メールを送信しています。
+        message_unconfirmed: メールアドレスが（%{email}）変更されたため、メールを送信しています。
+        subject: メール変更完了
+      password_change:
+        greeting: "%{recipient}様"
+        message: パスワードが再設定されました。
+        subject: パスワードの変更について
+      reset_password_instructions:
+        action: パスワード変更
+        greeting: "%{recipient}様"
+        instruction: パスワード再設定の依頼を受けたため、メールを送信しています。下のリンクからパスワードの再設定ができます。
+        instruction_2: パスワード再設定の依頼をしていない場合、このメールを無視してください。
+        instruction_3: パスワードの再設定は、上のリンクから新しいパスワードを登録するまで完了しません。
+        subject: パスワードの再設定について
+      unlock_instructions:
+        action: アカウントのロック解除
+        greeting: "%{recipient}様"
+        instruction: アカウントのロックを解除するには下のリンクをクリックしてください。
+        message: ログイン失敗が繰り返されたため、アカウントはロックされています。
+        subject: アカウントのロック解除について
+    omniauth_callbacks:
+      failure: "%{kind} アカウントによる認証に失敗しました。理由：（%{reason}）"
+      success: "%{kind} アカウントによる認証に成功しました。"
+    passwords:
+      edit:
+        change_my_password: パスワードを変更する
+        change_your_password: パスワードを変更
+        confirm_new_password: 確認用新しいパスワード
+        new_password: 新しいパスワード
+      new:
+        forgot_your_password: パスワードを忘れましたか？
+        send_me_reset_password_instructions: パスワードの再設定方法を送信する
+      no_token: このページにはアクセスできません。パスワード再設定メールのリンクからアクセスされた場合には、URL をご確認ください。
+      send_instructions: パスワードの再設定について数分以内にメールでご連絡いたします。
+      send_paranoid_instructions: メールアドレスが登録済みの場合、パスワード再設定用のメールが数分以内に送信されます。
+      updated: パスワードが正しく変更されました。
+      updated_not_active: パスワードが正しく変更されました。
+    registrations:
+      destroyed: アカウントを削除しました。またのご利用をお待ちしております。
+      edit:
+        are_you_sure: 本当によろしいですか？
+        cancel_my_account: アカウント削除
+        currently_waiting_confirmation_for_email: "%{email} の確認待ち"
+        leave_blank_if_you_don_t_want_to_change_it: 空欄のままなら変更しません
+        title: "%{resource}編集"
+        unhappy: 気に入りません
+        update: 更新
+        we_need_your_current_password_to_confirm_your_changes: 変更を反映するには現在のパスワードを入力してください
+      new:
+        sign_up: アカウント登録
+      signed_up: アカウント登録が完了しました。
+      signed_up_but_inactive: ログインするためには、アカウントを有効化してください。
+      signed_up_but_locked: アカウントがロックされているためログインできません。
+      signed_up_but_unconfirmed: 本人確認用のメールを送信しました。メール内のリンクからアカウントを有効化させてください。
+      update_needs_confirmation: アカウント情報を変更しました。変更されたメールアドレスの本人確認のため、本人確認用メールより確認処理をおこなってください。
+      updated: アカウント情報を変更しました。
+      updated_but_not_signed_in: あなたのアカウントは正常に更新されましたが、パスワードが変更されたため、再度ログインしてください。
+    sessions:
+      already_signed_out: 既にログアウト済みです。
+      new:
+        sign_in: ログイン
+      signed_in: ログインしました。
+      signed_out: ログアウトしました。
+    shared:
+      links:
+        back: 戻る
+        didn_t_receive_confirmation_instructions: アカウント確認のメールを受け取っていませんか？
+        didn_t_receive_unlock_instructions: アカウントのロック解除方法のメールを受け取っていませんか？
+        forgot_your_password: パスワードを忘れましたか？
+        sign_in: ログイン
+        sign_in_with_provider: "%{provider}でログイン"
+        sign_up: アカウント登録
+      minimum_password_length: "（%{count}字以上）"
+    unlocks:
+      new:
+        resend_unlock_instructions: アカウントのロック解除方法を再送する
+      send_instructions: アカウントのロック解除方法を数分以内にメールでご連絡します。
+      send_paranoid_instructions: アカウントが見つかった場合、アカウントのロック解除方法を数分以内にメールでご連絡します。
+      unlocked: アカウントをロック解除しました。
+  errors:
+    messages:
+      already_confirmed: は既に登録済みです。ログインしてください。
+      confirmation_period_expired: の期限が切れました。%{period} までに確認する必要があります。 新しくリクエストしてください。
+      expired: の有効期限が切れました。新しくリクエストしてください。
+      not_found: は見つかりませんでした。
+      not_locked: はロックされていません。
+      not_saved:
+        one: エラーが発生したため %{resource} は保存されませんでした。
+        other: "%{count} 件のエラーが発生したため %{resource} は保存されませんでした。"
+    

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,0 +1,38 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+      post: 投稿
+    attributes:
+      user:
+        email: Eメール
+        password: パスワード
+        password_confirmation: パスワード（確認用）
+        name: 名前
+      post:
+        title: タイトル
+        content: 内容
+        user_id: ユーザーID
+    errors:
+      models:
+        user:
+          attributes:
+            email:
+              blank: "Eメールを入力してください"
+              taken: "Eメールはすでに使用されています"
+            password:
+              blank: "パスワードを入力してください"
+              too_short: "パスワードは%{count}文字以上で入力してください"
+            password_confirmation:
+              blank: "パスワード（確認用）を入力してください"
+              confirmation: "パスワードが一致しません"
+            name:
+              blank: "名前を入力してください"
+        post:
+          attributes:
+            title:
+              blank: "タイトルを入力してください"
+            content:
+              blank: "内容を入力してください"
+            user_id:
+              blank: "ユーザーIDを入力してください"


### PR DESCRIPTION
This pull request introduces internationalization (i18n) support for the application, refactors the `PostsController`, and updates some views to improve user experience. The most important changes include adding new gems for i18n, setting the default locale, and adding localization files for Devise and models.

Internationalization (i18n) support:

* Added `rails-i18n` and `devise-i18n` gems to the `Gemfile` to support internationalization.
* Set the default locale to Japanese in `config/application.rb`.
* Added localization files `config/locales/devise.views.ja.yml` and `config/locales/models/ja.yml` to provide Japanese translations for Devise and model attributes. [[1]](diffhunk://#diff-20bdce1ac3bf55bf210efc9a858398c9bf71780057d1b9b4718d4e2a75b34a39R1-R144) [[2]](diffhunk://#diff-1f9088e5b169bb0cc32a91e691737501e5214d6d14177d19cda1098554d9ddbeR1-R38)

Controller refactoring:

* Removed redundant comments and streamlined the `PostsController` by eliminating unnecessary code. [[1]](diffhunk://#diff-41547fca0ee5b1e4a7a2be25356b71d2fc7389aa1e86fe97fc10cd6f48d1c6dbL5-L24) [[2]](diffhunk://#diff-41547fca0ee5b1e4a7a2be25356b71d2fc7389aa1e86fe97fc10cd6f48d1c6dbL34-L39)

View updates:

* Updated `app/views/layouts/application.html.erb` to disable Turbo for certain links to ensure proper navigation behavior.
* Replaced `link_to` with `button_to` in `app/views/posts/index.html.erb` for better form submission handling and disabled Turbo for these buttons.