### PR TITLE
日付のずれを修正しました。

### DIFF
--- a/app/views/posts/_today_separator_line.html.erb
+++ b/app/views/posts/_today_separator_line.html.erb
@@ -1,7 +1,7 @@
   <div class="flex items-center w-3/4 my-4 mx-auto">
     <div class="flex-grow h-px bg-text-muted/60"></div>
     <span class="px-3 text-sm text-text-muted whitespace-nowrap">
-      本日は<%= Time.zone.today.in_time_zone('Asia/Tokyo').strftime("%m/%d") %>です！
+      本日は<%= Time.zone.now.in_time_zone('Asia/Tokyo').strftime("%m/%d") %>です！
     </span>
     <div class="flex-grow h-px bg-text-muted/60"></div>
   </div>


### PR DESCRIPTION
This pull request includes a small change to the `app/views/posts/_today_separator_line.html.erb` file. The change updates the date display to use the current time instead of just today's date.

* [`app/views/posts/_today_separator_line.html.erb`](diffhunk://#diff-6a341fa8c6aaed2c1722c9807129b45420db93566b33ce9ca273da759b35a84bL4-R4): Changed from `Time.zone.today` to `Time.zone.now` to display the current date and time in Tokyo time zone.