### PR TITLE
モバイル版のダークモードトグルボタンを削除。時間によってデフォルトモード設定

### DIFF
--- a/app/javascript/application.js
+++ b/app/javascript/application.js
@@ -17,7 +17,15 @@ document.addEventListener("turbo:load", function() {
 
 document.addEventListener('DOMContentLoaded', () => {
   // システムの設定を確認
-  if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
-    document.documentElement.classList.add('dark');
-  }
+  // 6:00 - 18:00 はライトモード
+  // 18:00 - 6:00 はダークモード
+  // 日本時間に変換して判定
+  // html に dark または light クラスを追加
+
+  const now = new Date();
+  const hours = now.getHours();
+  const darkMode = hours < 6 || hours >= 18;
+  const html = document.querySelector('html');
+  html.classList.add(darkMode ? 'dark' : 'light');
+
 });

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,7 +55,7 @@
           </div>
           <!-- Mobile Menu Toggle Button -->
           <div class="md:hidden flex items-center"> 
-            <%= render partial: "/darkmode_toggle_button" %>
+            <%#= render partial: "/darkmode_toggle_button" %>
             <button id="mobile-menu-button" class="text-gray-500 ml-2 hover:text-gray-800 focus:outline-none focus:ring-2 focus:ring-gray-200">
               <svg class="h-6 w-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16m-7 6h7" />

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,7 +1,7 @@
 <div class='pt-32 pb-12 md:pt-40 md:pb-20'>
   <div class='pb-12 text-center md:pb-16'>
     <h1 class='leading-tighter mx-4 mb-4 text-4xl font-extrabold tracking-tighter md:text-8xl'>
-      <span class='p-2 bg-gradient-to-r from-primary to-secondary bg-clip-text text-transparent dark:bg-gradient-to-r from-orage-500 to-green-500'>
+      <span class='p-2 bg-gradient-to-r from-blue-600 to-green-500 bg-clip-text text-transparent'>
         本日も張り切って！
       </span>
     </h1>


### PR DESCRIPTION
This pull request includes changes to improve the dark mode functionality and update the user interface. The most important changes include modifying the dark mode logic in JavaScript, commenting out the dark mode toggle button in the mobile menu, and updating the gradient color in the home page heading.

Improvements to dark mode functionality:

* [`app/javascript/application.js`](diffhunk://#diff-baa2004cc77a893ed291cbf22ae1a4f3b8476a67d4581ea3928109e5ea211df4L20-R30): Modified the dark mode logic to switch between light and dark modes based on the time of day, specifically from 6:00 to 18:00 for light mode and 18:00 to 6:00 for dark mode.

User interface updates:

* [`app/views/layouts/application.html.erb`](diffhunk://#diff-f43fe075643e681b2c01c2f853bb0c4299d135b47fcbd4da96890d521c49e3ebL58-R58): Commented out the dark mode toggle button in the mobile menu.
* [`app/views/pages/home.html.erb`](diffhunk://#diff-8c80b6626c38cda1f173a92f4709a673ee5ed4bbb14d96d20afefecd730b029aL4-R4): Updated the gradient color in the home page heading from a dark mode-specific gradient to a consistent blue-to-green gradient.