### PR TITLE
投稿表示のアニメーション改善

### DIFF
--- a/app/javascript/posts_show_delay.js
+++ b/app/javascript/posts_show_delay.js
@@ -1,41 +1,33 @@
 export function setupPostsShowDelay() {
-  const postsLeft = Array.from(document.querySelectorAll('#login-histories .ease_in_left')).slice(0, 10);
-  const postsRight = Array.from(document.querySelectorAll('#login-histories .ease_in_right')).slice(0, 10);
-  if (postsLeft.length === 0 && postsRight.length === 0) {
+  const posts = Array.from(document.querySelectorAll('.posts')).slice(0, 20);
+
+  if (posts.length === 0) {
     return;
   }
-  // 初期状態: 要素を占有しつつ見えない状態にする
-  postsLeft.forEach(post => {
+
+  posts.forEach(post => {
     post.style.visibility = 'hidden';
   });
 
-  postsRight.forEach(post => {
-    post.style.visibility = 'hidden';
-  });
+  let indexpost = 0;
 
-  let indexLeft = 0;
-  let indexRight = 0;
+  const showPost = () => {
+    posts[indexpost].style.visibility = 'visible';
 
-  const showPostLeft = () => {
-    postsLeft[indexLeft].style.visibility = 'visible'; // 表示
-    postsLeft[indexLeft].classList.add('animate-ease_in_left'); // アニメーション
-    indexLeft++;
+    if (posts[indexpost].classList.contains('ease_in_right')) {
+      posts[indexpost].classList.add('animate-ease_in_right');
+    }
+    if (posts[indexpost].classList.contains('ease_in_left')) {
+      posts[indexpost].classList.add('animate-ease_in_left');
+    }
 
-    if (indexLeft < postsLeft.length) {
-      setTimeout(showPostLeft, 200);
+    indexpost++;
+
+    if (indexpost< posts.length) {
+      setTimeout(showPost, 200);
     }
   };
 
-  const showPostRight = () => {
-    postsRight[indexRight].style.visibility = 'visible'; // 表示
-    postsRight[indexRight].classList.add('animate-ease_in_right'); // アニメーション
-    indexRight++;
 
-    if (indexRight < postsRight.length) {
-      setTimeout(showPostRight, 200);
-    }
-  };
-
-  showPostLeft();
-  showPostRight();
+  showPost();
 }

--- a/app/views/posts/_ganbaru_post.html.erb
+++ b/app/views/posts/_ganbaru_post.html.erb
@@ -11,7 +11,7 @@
 <!-- post -->
 <div class="w-full max-w-sm flex items-start">
   <%= link_to post_path(post), class: "inline-block w-full max-w-[80%]" do %>
-      <div class="hover:scale-105 transition-transform w-full ease_in_left">
+      <div class="posts hover:scale-105 transition-transform w-full ease_in_left">
         <!-- メッセージ吹き出し -->
         <div class="relative bg-emerald-100 rounded-2xl p-4 w-full inline-block">
           <!-- 左上の三角形 -->

--- a/app/views/posts/_konohende_post.html.erb
+++ b/app/views/posts/_konohende_post.html.erb
@@ -9,7 +9,7 @@
 
 <div class="w-full max-w-sm flex items-start flex-row-reverse space-x-reverse">
   <%= link_to post_path(post), class: "inline-block w-full max-w-[80%]" do %>
-        <div class="hover:scale-105 transition-transform w-full ease_in_right">
+        <div class="posts hover:scale-105 transition-transform w-full ease_in_right">
           <!-- メッセージ吹き出し -->
           <div class="relative bg-blue-100 rounded-2xl p-4 w-full">
             <!-- 右上の三角形 -->

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -18,7 +18,7 @@
     <% if @posts.index(post) > 0 && post.created_at.in_time_zone('Asia/Tokyo').strftime("%m/%d") != @posts[@posts.index(post) - 1].created_at.in_time_zone('Asia/Tokyo').strftime("%m/%d") %>
       <%= render partial: "day_separator_line", locals: { post: post } %>
     <% end %>
-    <div id="posts" class="w-full max-w-2xl flex flex-col items-center max-w-[95%]">
+    <div class="w-full max-w-2xl flex flex-col items-center max-w-[95%]">
       <%= render partial: "post", locals: { post: post } %>
     </div>
   <% end %>


### PR DESCRIPTION
- `app/javascript/posts_show_delay.js`:
  - 左右のポスト表示ロジックを統一し、コードをシンプル化
  - セレクタを '.posts' クラスに変更して共通処理に修正

- `app/views/posts/_ganbaru_post.html.erb` と `app/views/posts/_konohende_post.html.erb`:
  - 投稿要素に 'posts' クラスを追加してアニメーション処理の対象に

- `app/views/posts/index.html.erb`:
  - 不要な id="posts" 属性を削除